### PR TITLE
Fix MinecraftForge repo not having the artifact metadata source enabled

### DIFF
--- a/src/base/kotlin/club/ampthedev/mcgradle/base/BasePlugin.kt
+++ b/src/base/kotlin/club/ampthedev/mcgradle/base/BasePlugin.kt
@@ -31,7 +31,11 @@ abstract class BasePlugin<T : BaseExtension> : Plugin<Project> {
 
     open fun setup(project: Project) {
         project.repositories.mavenCentral()
-        project.repositories.maven { it.setUrl("https://maven.minecraftforge.net/") }
+        project.repositories.maven {
+            it.setUrl("https://maven.minecraftforge.net/")
+            it.metadataSources.mavenPom()
+            it.metadataSources.artifact()
+        }
         project.repositories.maven { it.setUrl("https://libraries.minecraft.net") }
 
         project.addReplacements(mapOf(


### PR DESCRIPTION
In Gradle 6.0 and above, the `artifact` metadata source is not enabled by default for performance reasons. This metadata source is required for resolving legacy MCP mappings (for example, if 1.8.9 development is desired). 